### PR TITLE
feat: add organization unit and account

### DIFF
--- a/platform/organizations.tf
+++ b/platform/organizations.tf
@@ -1,0 +1,30 @@
+data "aws_organizations_organization" "main" {}
+
+resource "aws_organizations_organizational_unit" "foundational" {
+  name      = "Foundational"
+  parent_id = data.aws_organizations_organization.main.roots[0].id
+}
+
+resource "aws_organizations_organizational_unit" "additional" {
+  name      = "Additional"
+  parent_id = data.aws_organizations_organization.main.roots[0].id
+}
+
+resource "aws_organizations_organizational_unit" "security" {
+  name      = "Security"
+  parent_id = aws_organizations_organizational_unit.foundational.id
+}
+
+resource "aws_organizations_account" "audit" {
+  name              = "Audit"
+  email             = "wakabaseisei+audit@gmail.com"
+  parent_id         = aws_organizations_organizational_unit.security.id
+  close_on_deletion = true
+}
+
+resource "aws_organizations_account" "log_archive" {
+  name              = "Log-Archive"
+  email             = "wakabaseisei+log-archive@gmail.com"
+  parent_id         = aws_organizations_organizational_unit.security.id
+  close_on_deletion = true
+}


### PR DESCRIPTION
## WHAT
- Add AWS Organization Unit `Foundational OU` and `Additional OU`
  - The `Security OU` is placed under the `Foundational OU`.
- Add AWS Account `Audit` and `Log-Archive` is placed under the `Security OU`.

AWS Account The default limit for AWS accounts that can be created within an organization is set at 10, but apparently it may be less if the organization has just been created([doc reference](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_limits.html#:~:text=Newly%20created%20accounts%20and%20organizations%20might%20experience%20a%20quota%20below%20the%20default%20of%2010%20accounts.)).
<img width="1462" alt="スクリーンショット 2024-11-08 22 16 08" src="https://github.com/user-attachments/assets/ea98f536-7910-4e5c-b8bf-4bd3230a7aeb">



